### PR TITLE
Fix date.between

### DIFF
--- a/lib/src/date.dart
+++ b/lib/src/date.dart
@@ -47,7 +47,9 @@ class Date {
   /// ```
   DateTime between(DateTime start, DateTime end) {
     final diff = end.millisecondsSinceEpoch - start.millisecondsSinceEpoch;
-    final randomMilliseconds = _faker.datatype.number(max: diff);
+    final randomMilliseconds = (_faker.datatype.number(max: 1 << 32) * (1 << 32) +
+            _faker.datatype.number(max: 1 << 32)) %
+        diff;
 
     return start.add(Duration(milliseconds: randomMilliseconds));
   }

--- a/lib/src/date.dart
+++ b/lib/src/date.dart
@@ -47,9 +47,9 @@ class Date {
   /// ```
   DateTime between(DateTime start, DateTime end) {
     final diff = end.millisecondsSinceEpoch - start.millisecondsSinceEpoch;
-    final randomDays = _faker.datatype.number(max: (diff / 86400000).round());
+    final randomMilliseconds = _faker.datatype.number(max: diff);
 
-    return start.add(Duration(milliseconds: randomDays));
+    return start.add(Duration(milliseconds: randomMilliseconds));
   }
 
   /// generates a random month name or [abbreviated] month name


### PR DESCRIPTION
`randomDays` had the unit of "days" but it was sent to `Duration` constructor as `milliseconds` which caused all the randomly generated dates to be very close to the `start`.